### PR TITLE
FRRouting support RFC 8212 as of version 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you observe a mistake on this page or if you can contribute an update, please
 * BIRD (version 2.0.1 and higher)
 * OpenBGPD (OpenBSD 6.4 and higher)
 * Nokia SR OS (19.5.R1 or higher)
+* FRRouting (7.0 or higher)
 
 # Non-compliant BGP implementations
 
@@ -24,7 +25,6 @@ If you observe a mistake on this page or if you can contribute an update, please
 * Cisco NX-OS
 * Juniper Junos <sup>[2](#fn2)</sup>
 * Quagga
-* frr
 
 # Footnotes
 


### PR DESCRIPTION
- PR was merged Feb 19th. https://github.com/FRRouting/frr/pull/3746
- FRRouting 7.0 was released March 13th. https://github.com/FRRouting/frr/releases/tag/frr-7.0