### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you observe a mistake on this page or if you can contribute an update, please
 * Juniper Junos <sup>[3](#fn3)</sup>
 * Quagga
 * Extreme IronWare
+* Huawei VRP
 
 # Footnotes
 


### PR DESCRIPTION
Added Huawei Versatile Routing Platform (VRP) to "Non-compliant BGP implementations" list.