### PR TITLE
Add Nokia SR Linux to compliant list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If you observe a mistake on this page or if you can contribute an update, please
 * Nokia SR OS (19.5.R1 and higher)
 * FRRouting (7.4 and higher)
 * Bio routing / bio-rd
+* Nokia SR Linux
 
 # Non-compliant BGP implementations
 


### PR DESCRIPTION
Nokia SR Linux is compliant with RFC8212 (tested on v21.6.2)